### PR TITLE
Rewrite Buffer class.

### DIFF
--- a/Source/Game/BlueBlur/BBWorkHandler.cpp
+++ b/Source/Game/BlueBlur/BBWorkHandler.cpp
@@ -125,25 +125,24 @@ HOOK(void, __fastcall, CDatabaseLoaderLoadArchiveList, 0x69B360,
 	{
 		const size_t curSplitCount = archiveList->m_ArchiveSizes.size();
 
-		const auto buffer = std::unique_ptr<Buffer>{ read_file((*it).path.c_str(), false) };
-		if (buffer != nullptr)
+		auto buffer = read_file(it->path, false);
+		if (buffer.has_value())
 		{
-			auto shared_buffer = boost::shared_ptr<uint8_t[]>{ buffer->memory };
-			auto buffer_size = buffer->size;
-			buffer->memory = nullptr;
-
-			DecompressCAB(shared_buffer, buffer_size);
-			originalCDatabaseLoaderLoadArchiveList(This, _, archiveList, shared_buffer.get(), buffer_size);
+			auto [data, len] = Buffer::leak(std::move(*buffer));
+			boost::shared_ptr<uint8_t[]> shared_buffer{ data };
+			
+			DecompressCAB(shared_buffer, len);
+			originalCDatabaseLoaderLoadArchiveList(This, _, archiveList, data, len);
 
 			char appendArPath[0x400];
-			strcpy(appendArPath, (*it).path.c_str());
+			strcpy(appendArPath, it->path.c_str());
 
 			for (size_t i = curSplitCount; i < archiveList->m_ArchiveSizes.size(); i++)
 			{
 				sprintf(name + nameSize, ".ar.%02d", i);
-				sprintf(appendArPath + (*it).path.size() - 1, ".%02d", archiveList->m_ArchiveSizes.size() - i - 1); // .arl -> .ar.%02d
+				sprintf(appendArPath + it->path.size() - 1, ".%02d", archiveList->m_ArchiveSizes.size() - i - 1); // .arl -> .ar.%02d
 
-				g_binder->BindFile(name, appendArPath, (*it).bind.priority);
+				g_binder->BindFile(name, appendArPath, it->bind.priority);
 			}
 		}
 	}

--- a/Source/Mod.cpp
+++ b/Source/Mod.cpp
@@ -13,15 +13,15 @@ bool Mod::Load(const std::string& path)
 	this->path = path;
 	root = modPath.parent_path().string();
 
-	const auto file = std::unique_ptr<Buffer>(read_file(path.c_str(), true));
+	const auto file = read_file(path, true);
 
-	if (file == nullptr)
+	if (!file.has_value())
 	{
 		LOG("Failed to load mod: %s", path.c_str());
 		return false;
 	}
 
-	const Ini ini{ reinterpret_cast<char*>(file->memory), nullptr };
+	const Ini ini{ reinterpret_cast<const char*>(file->as_ptr()), nullptr };
 	const auto mainSection = ini["Main"];
 	const auto descSection = ini["Desc"];
 	const auto cpksSection = ini["CPKs"];
@@ -128,13 +128,13 @@ void Mod::Init(int in_bind_priority)
 	for (auto& config : cpk_configs)
 	{
 		const auto path = (root / config.name);
-		const auto file = std::unique_ptr<Buffer>(read_file(path.string().c_str(), true));
-		if (file == nullptr)
+		const auto file = read_file(path.string(), true);
+		if (!file.has_value())
 		{
 			continue;
 		}
 
-		config.Parse(reinterpret_cast<char*>(file->memory));
+		config.Parse(reinterpret_cast<const char*>(file->as_ptr()));
 		config.Process(*loader->binder, path.parent_path(), bind_priority);
 	}
 }

--- a/Source/ModLoader.cpp
+++ b/Source/ModLoader.cpp
@@ -62,9 +62,9 @@ void ModLoader::Init(const char* configPath)
 
 	const bool isLegacy = stricmp(path_filename(configPath), MODLOADER_LEGACY_CONFIG_NAME) == 0;
 
-	const auto file = std::unique_ptr<Buffer>(read_file(config_path.c_str(), true));
+	const auto file = read_file(config_path, true);
 
-	const Ini ini{ reinterpret_cast<char*>(file != nullptr ? file->memory : nullptr) };
+	const Ini ini{ reinterpret_cast<const char*>(file.has_value() ? file->as_ptr() : nullptr)};
 	const auto cpkSection = ini[isLegacy ? "CPKREDIR" : "HEDGEHOG"];
 
 	if (strcmp(cpkSection["Enabled"], "0") == 0)
@@ -123,14 +123,14 @@ void ModLoader::LoadDatabase(const std::string& databasePath, bool append)
 	codesPath.append("\\Codes.dll");
 	CommonLoader::LoadAssembly(codesPath.c_str());
 
-	const auto file = std::unique_ptr<Buffer>(read_file(database_path.c_str(), true));
-	if (!file)
+	const auto file = read_file(database_path, true);
+	if (!file.has_value())
 	{
 		return;
 	}
 
 	char buf[32];
-	const auto ini = Ini{ reinterpret_cast<char*>(file->memory) };
+	const auto ini = Ini{ reinterpret_cast<const char*>(file->as_ptr()) };
 	const auto mainSection = ini["Main"];
 	const auto modsSection = ini["Mods"];
 

--- a/Source/Pch.h
+++ b/Source/Pch.h
@@ -13,6 +13,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <unordered_map>
+#include <optional>
 
 #include <CommonLoader.h>
 

--- a/Source/Utilities.h
+++ b/Source/Utilities.h
@@ -33,6 +33,7 @@ public:
 		other.memory = nullptr;
 		size = other.size;
 		other.size = 0;
+		return *this;
 	}
 	inline uint8_t* as_mut_ptr() {
 		return memory;


### PR DESCRIPTION
Rewrites the ``Buffer`` class in Utilities.h to block copies at compile-time and leverage move semantics; removing the need for detection of ownership via a bitfield.